### PR TITLE
feat: amélioration de l'API des catégories

### DIFF
--- a/backend-implicaction/src/main/java/com/dynonuggets/refonteimplicaction/adapter/forum/CategoryAdapter.java
+++ b/backend-implicaction/src/main/java/com/dynonuggets/refonteimplicaction/adapter/forum/CategoryAdapter.java
@@ -3,11 +3,8 @@ package com.dynonuggets.refonteimplicaction.adapter.forum;
 import com.dynonuggets.refonteimplicaction.dto.forum.CategoryDto;
 import com.dynonuggets.refonteimplicaction.dto.forum.CreateCategoryDto;
 import com.dynonuggets.refonteimplicaction.model.forum.Category;
-import org.apache.commons.collections4.CollectionUtils;
 import org.springframework.stereotype.Component;
 
-import java.util.ArrayList;
-import java.util.List;
 import java.util.stream.Collectors;
 
 @Component
@@ -27,27 +24,22 @@ public class CategoryAdapter {
                 .build();
     }
 
+    public CategoryDto toDtoWithoutChildren(Category model) {
+        return CategoryDto.builder()
+                .id(model.getId())
+                .title(model.getTitle())
+                .description(model.getDescription())
+                .parentId(model.getParent() != null ? model.getParent().getId() : null)
+                .build();
+    }
+
     public CategoryDto toDto(Category model) {
         return CategoryDto.builder()
                 .id(model.getId())
                 .title(model.getTitle())
                 .description(model.getDescription())
-                .children(new ArrayList<>())
                 .parentId(model.getParent() != null ? model.getParent().getId() : null)
-                .build();
-    }
-
-    public CategoryDto toDtoWithChildren(Category model) {
-        List<CategoryDto> children = CollectionUtils.isNotEmpty(model.getChildren())
-                ? model.getChildren().stream().map(this::toDtoWithChildren).collect(Collectors.toList())
-                : new ArrayList<>();
-        return CategoryDto.builder()
-                .id(model.getId())
-                .title(model.getTitle())
-                .description(model.getDescription())
-                .children(new ArrayList<>())
-                .parentId(model.getParent() != null ? model.getParent().getId() : null)
-                .children(children)
+                .children(model.getChildren().stream().map(Category::getId).collect(Collectors.toList()))
                 .build();
     }
 }

--- a/backend-implicaction/src/main/java/com/dynonuggets/refonteimplicaction/adapter/forum/TopicAdapter.java
+++ b/backend-implicaction/src/main/java/com/dynonuggets/refonteimplicaction/adapter/forum/TopicAdapter.java
@@ -72,7 +72,7 @@ public class TopicAdapter {
                 .isPinned(model.isPinned())
                 .isLocked(model.isLocked())
                 .author(userAdapter.toDto(model.getAuthor()))
-                .category(categoryAdapter.toDto(model.getCategory()))
+                .category(categoryAdapter.toDtoWithoutChildren(model.getCategory()))
                 .responses(new ArrayList<>())
                 .build();
     }

--- a/backend-implicaction/src/main/java/com/dynonuggets/refonteimplicaction/controller/forum/ForumCategoriesController.java
+++ b/backend-implicaction/src/main/java/com/dynonuggets/refonteimplicaction/controller/forum/ForumCategoriesController.java
@@ -15,6 +15,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
+import java.util.stream.Collectors;
 
 import static com.dynonuggets.refonteimplicaction.utils.ApiUrls.*;
 import static org.springframework.http.HttpStatus.CREATED;
@@ -27,7 +28,10 @@ public class ForumCategoriesController {
     private final TopicService topicService;
 
     @GetMapping
-    public ResponseEntity<List<CategoryDto>> getAllCategories() throws ImplicactionException {
+    public ResponseEntity<List<CategoryDto>> getAllCategories(@RequestParam(defaultValue = "false") boolean onlyRoot) throws ImplicactionException {
+        if (onlyRoot) {
+            return ResponseEntity.ok(categoryService.getRootCategories());
+        }
         return ResponseEntity.ok(categoryService.getCategories());
     }
 
@@ -38,9 +42,11 @@ public class ForumCategoriesController {
     }
 
     @GetMapping(GET_CATEGORY_URI)
-    public ResponseEntity<CategoryDto> getCategory(@PathVariable long categoryId) {
-        CategoryDto foundDto = categoryService.getCategory(categoryId);
-        return ResponseEntity.ok(foundDto);
+    public ResponseEntity<List<CategoryDto>> getCategory(@PathVariable List<Long> categoryIds) {
+        List<CategoryDto> categories = categoryIds.stream()
+                .map(categoryService::getCategory)
+                .collect(Collectors.toList());
+        return ResponseEntity.ok(categories);
     }
 
     @GetMapping(GET_TOPIC_FROM_CATEGORY_URI)

--- a/backend-implicaction/src/main/java/com/dynonuggets/refonteimplicaction/dto/forum/CategoryDto.java
+++ b/backend-implicaction/src/main/java/com/dynonuggets/refonteimplicaction/dto/forum/CategoryDto.java
@@ -2,7 +2,6 @@ package com.dynonuggets.refonteimplicaction.dto.forum;
 
 import lombok.*;
 
-import java.util.ArrayList;
 import java.util.List;
 
 @Data
@@ -15,5 +14,5 @@ public class CategoryDto {
     private String title;
     private String description;
     private Long parentId;
-    private List<CategoryDto> children = new ArrayList<>();
+    private List<Long> children;
 }

--- a/backend-implicaction/src/main/java/com/dynonuggets/refonteimplicaction/repository/forum/CategoryRepository.java
+++ b/backend-implicaction/src/main/java/com/dynonuggets/refonteimplicaction/repository/forum/CategoryRepository.java
@@ -3,5 +3,8 @@ package com.dynonuggets.refonteimplicaction.repository.forum;
 import com.dynonuggets.refonteimplicaction.model.forum.Category;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+
 public interface CategoryRepository extends JpaRepository<Category, Long> {
+    List<Category> findByParentIdIsNull();
 }

--- a/backend-implicaction/src/main/java/com/dynonuggets/refonteimplicaction/service/forum/CategoryService.java
+++ b/backend-implicaction/src/main/java/com/dynonuggets/refonteimplicaction/service/forum/CategoryService.java
@@ -7,15 +7,11 @@ import com.dynonuggets.refonteimplicaction.exception.ImplicactionException;
 import com.dynonuggets.refonteimplicaction.exception.NotFoundException;
 import com.dynonuggets.refonteimplicaction.model.forum.Category;
 import com.dynonuggets.refonteimplicaction.repository.forum.CategoryRepository;
-import com.dynonuggets.refonteimplicaction.repository.forum.ResponseRepository;
-import com.dynonuggets.refonteimplicaction.repository.forum.TopicRepository;
 import lombok.AllArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 import java.util.stream.Collectors;
 
 import static com.dynonuggets.refonteimplicaction.utils.Message.CATEGORY_NOT_FOUND_MESSAGE;
@@ -24,31 +20,19 @@ import static com.dynonuggets.refonteimplicaction.utils.Message.CATEGORY_NOT_FOU
 @AllArgsConstructor
 public class CategoryService {
     private final CategoryRepository categoryRepository;
-    private final TopicRepository topicRepository;
-    private final ResponseRepository responseRepository;
     private final CategoryAdapter categoryAdapter;
 
     @Transactional
     public List<CategoryDto> getCategories() {
-        Map<Long, CategoryDto> categoryMap = new HashMap<>();
         return categoryRepository.findAll().stream()
-                // transforme tous les modeles en DTO
                 .map(categoryAdapter::toDto)
-                // ajoute chaque categorie dans une map
-                .peek(categoryDto -> categoryMap.put(categoryDto.getId(), categoryDto))
-                // ajoute chaque catégorie à son parent (si elles en ont un)
-                .peek(categoryDto -> {
-                    // on récupère le parent de la catégorie
-                    CategoryDto parentCategory = categoryMap.get(categoryDto.getParentId());
-                    if (parentCategory == null) {
-                        return;
-                    }
-                    // on ajoute la catégorie actuelle dans la liste des enfants du parent
-                    parentCategory.getChildren().add(categoryDto);
-                })
-                // finalement, on ne garde dans le tableau QUE les catégories qui n'ont pas de parent (la racine)
-                // puisque maintenant toutes les catégories ont leurs enfants
-                .filter(categoryDto -> categoryDto.getParentId() == null)
+                .collect(Collectors.toList());
+    }
+
+    @Transactional
+    public List<CategoryDto> getRootCategories() {
+        return categoryRepository.findByParentIdIsNull().stream()
+                .map(categoryAdapter::toDto)
                 .collect(Collectors.toList());
     }
 
@@ -57,7 +41,7 @@ public class CategoryService {
         Category category = categoryRepository.findById(id)
                 .orElseThrow(() -> new NotFoundException(String.format(CATEGORY_NOT_FOUND_MESSAGE, id)));
 
-        return categoryAdapter.toDtoWithChildren(category);
+        return categoryAdapter.toDto(category);
     }
 
     @Transactional

--- a/backend-implicaction/src/main/java/com/dynonuggets/refonteimplicaction/utils/ApiUrls.java
+++ b/backend-implicaction/src/main/java/com/dynonuggets/refonteimplicaction/utils/ApiUrls.java
@@ -71,7 +71,7 @@ public class ApiUrls {
 
     // FORUM CATEGORIES
     public static final String CATEGORY_BASE_URI = "/api/forum/categories";
-    public static final String GET_CATEGORY_URI = "/{categoryId}";
+    public static final String GET_CATEGORY_URI = "/{categoryIds}";
 
     public static final String GET_TOPIC_FROM_CATEGORY_URI = "/{categoryId}/topics";
 

--- a/frontend-implicaction/src/app/core/services/api-endpoints.service.ts
+++ b/frontend-implicaction/src/app/core/services/api-endpoints.service.ts
@@ -44,8 +44,10 @@ export class ApiEndpointsService {
     let encodedPathVariablesUrl = '';
     // Push extra path variables
     for (const pathVariable of pathVariables) {
+      let pathVariableStr = pathVariable instanceof Array ? pathVariable.join(',') : pathVariable;
+
       if (pathVariable !== null) {
-        encodedPathVariablesUrl += `/${encodeURIComponent(pathVariable.toString())}`;
+        encodedPathVariablesUrl += `/${encodeURIComponent(pathVariableStr.toString())}`;
       }
     }
     const urlBuilder: UrlBuilder = new UrlBuilder(Constants.API_ENDPOINT, `${action}${encodedPathVariablesUrl}`);
@@ -391,12 +393,24 @@ export class ApiEndpointsService {
    * FORUM
    */
 
-  getAllCategories() {
+  getCategories(): string;
+  getCategories(ids: number[]): string;
+  getCategories(ids?: number[]) {
+    if (ids) {
+      return ApiEndpointsService.createUrlWithPathVariables(Uris.FORUM.CATEGORIES, [ids]);
+    }
     return ApiEndpointsService.createUrl(Uris.FORUM.CATEGORIES);
   }
 
+  getRootCategories() {
+    return ApiEndpointsService.createUrlWithQueryParameters(Uris.FORUM.CATEGORIES, (queryParams) => {
+      queryParams.push("onlyRoot", true);
+      return queryParams;
+    });
+  }
+
   getCategory(id: number) {
-    return ApiEndpointsService.createUrlWithPathVariables(Uris.FORUM.CATEGORIES, [id]);
+    return this.getCategories([id]);
   }
 
   getCategoryTopics(id: number, pageable: Pageable<any>) {

--- a/frontend-implicaction/src/app/forum/components/category-content/category-content.component.html
+++ b/frontend-implicaction/src/app/forum/components/category-content/category-content.component.html
@@ -1,13 +1,15 @@
-<div *ngIf="$category | async as category">
+<div *ngIf="category$ | async as category">
   <h2>{{ category.title }}</h2>
 
   <div *ngIf="category.children.length > 0">
     <h3>Sous-catégories</h3>
     <app-sub-category-list
-      [categories]="category.children"></app-sub-category-list>
+      *ngIf="subCategories$ | async as subCategories"
+      [categories]="subCategories"
+    ></app-sub-category-list>
   </div>
 
-  <div *ngIf="$paginatedTopics | async as paginatedTopics">
+  <div *ngIf="paginatedTopics$ | async as paginatedTopics">
     <h3>Sujets</h3>
     <app-topic-list [topics]="paginatedTopics.content"></app-topic-list>
   </div>

--- a/frontend-implicaction/src/app/forum/components/category-content/category-content.component.ts
+++ b/frontend-implicaction/src/app/forum/components/category-content/category-content.component.ts
@@ -18,16 +18,18 @@ import {Pageable} from "../../../shared/models/pageable";
 })
 export class CategoryContentComponent extends BaseWithPaginationAndFilterComponent<Topic, Criteria> implements OnInit {
 
-  $category: Observable<Category>;
-  $paginatedTopics: Observable<Pageable<Topic>>;
+  category$: Observable<Category>;
+  paginatedTopics$: Observable<Pageable<Topic>>;
+  subCategories$: Observable<Category[]>;
 
   constructor(private categoryService: CategoryService, private currentRoute: ActivatedRoute) {
     super(currentRoute);
   }
 
   ngOnInit(): void {
-    const $id = this.currentRoute.params.pipe(map(map => +map['id']))
-    this.$category = $id.pipe(switchMap(id => this.categoryService.getCategory(id)));
-    this.$paginatedTopics = $id.pipe(switchMap(id => this.categoryService.getCategoryTopics(id, this.pageable)));
+    const id$ = this.currentRoute.params.pipe(map(map => +map['id']));
+    this.category$ = id$.pipe(switchMap(id => this.categoryService.getCategory(id)));
+    this.subCategories$ = this.category$.pipe(switchMap(category => this.categoryService.getCategories(category.children)));
+    this.paginatedTopics$ = id$.pipe(switchMap(id => this.categoryService.getCategoryTopics(id, this.pageable)));
   }
 }

--- a/frontend-implicaction/src/app/forum/components/create-topic-form/create-topic-form.component.ts
+++ b/frontend-implicaction/src/app/forum/components/create-topic-form/create-topic-form.component.ts
@@ -1,20 +1,19 @@
 import {Component, OnInit} from '@angular/core';
 import {FormControl, FormGroup, Validators} from "@angular/forms";
 import {Category} from "../../model/category";
-import {CategoryService} from "../../services/category.service";
+import {CategoryNode, CategoryService} from "../../services/category.service";
 import {TopicService} from "../../services/topic.service";
 import {ToasterService} from "../../../core/services/toaster.service";
-import {Observable} from "rxjs";
 import {CreateTopicPayload} from "../../model/createTopicPayload";
 import {SidebarContentComponent} from "../../../shared/models/sidebar-props";
 import {SidebarService} from "../../../shared/services/sidebar.service";
 
-interface CategoryNode {
+interface CategoryTreeSelectNode {
   id: number;
   label: string;
   data: string;
   selectable: boolean;
-  children?: CategoryNode[];
+  children?: CategoryTreeSelectNode[];
 }
 
 @Component({
@@ -32,18 +31,19 @@ export class CreateTopicFormComponent extends SidebarContentComponent implements
     category: new FormControl<Category>(null, Validators.required)
   });
 
-  categoriesNodes: CategoryNode[];
+  categoriesNodes: CategoryTreeSelectNode[];
 
-  constructor(private categoryService: CategoryService,
-              private topicService: TopicService,
-              private toastService: ToasterService,
-              private sidebarService: SidebarService,
+  constructor(
+    private categoryService: CategoryService,
+    private topicService: TopicService,
+    private toastService: ToasterService,
+    private sidebarService: SidebarService,
   ) {
     super();
   }
 
   ngOnInit(): void {
-    const categories: Observable<Category[]> = this.categoryService.getCategories();
+    const categories = this.categoryService.getCategoryTree();
     categories.subscribe((val) => {
       this.categoriesNodes = this.categoriesToCategoriesNode(val);
     });
@@ -56,14 +56,14 @@ export class CreateTopicFormComponent extends SidebarContentComponent implements
       isPinned: this.topicForm.value.isPinned,
       isLocked: this.topicForm.value.isLocked,
       categoryId: this.topicForm.value.category.id
-    }
+    };
     this.topicService.createTopic(createTopic).subscribe(res => {
       this.toastService.success('Topic créé!', 'Le topic a bien été créé');
       this.sidebarService.close();
-    })
+    });
   }
 
-  private categoriesToCategoriesNode(categories: Category[]): CategoryNode[] {
+  private categoriesToCategoriesNode(categories: CategoryNode[]): CategoryTreeSelectNode[] {
     return categories.map(({id, title, parentId, children}) => ({
       id: id,
       label: title,

--- a/frontend-implicaction/src/app/forum/components/home/home.component.html
+++ b/frontend-implicaction/src/app/forum/components/home/home.component.html
@@ -1,5 +1,5 @@
 <ul>
-  <li *ngFor="let category of $categories | async">
+  <li *ngFor="let category of categories$ | async">
     {{ category.title }}
     <app-sub-category-list [categories]="category.children"></app-sub-category-list>
   </li>

--- a/frontend-implicaction/src/app/forum/components/home/home.component.ts
+++ b/frontend-implicaction/src/app/forum/components/home/home.component.ts
@@ -20,7 +20,6 @@ export class HomeComponent implements OnInit {
   ngOnInit(): void {
     this.categories$ = this.categoryService.getRootCategories()
       .pipe(switchMap(parentCategories => {
-        console.log(parentCategories);
         const children$ = this.fetchRootCategoriesChildren(parentCategories);
 
         return children$.pipe(

--- a/frontend-implicaction/src/app/forum/components/home/home.component.ts
+++ b/frontend-implicaction/src/app/forum/components/home/home.component.ts
@@ -2,6 +2,9 @@ import {Component, OnInit} from '@angular/core';
 import {Observable} from "rxjs";
 import {CategoryService} from "../../services/category.service";
 import {Category} from "../../model/category";
+import {map, switchMap} from "rxjs/operators";
+
+export type CategoryWithChildren = Omit<Category, "children"> & { children: Category[] };
 
 @Component({
   selector: 'app-home',
@@ -9,13 +12,40 @@ import {Category} from "../../model/category";
   styleUrls: ['./home.component.scss']
 })
 export class HomeComponent implements OnInit {
-  $categories: Observable<Category[]>;
+  categories$: Observable<CategoryWithChildren[]>;
 
   constructor(private categoryService: CategoryService) {
   }
 
   ngOnInit(): void {
-    this.$categories = this.categoryService.getCategories()
+    this.categories$ = this.categoryService.getRootCategories()
+      .pipe(switchMap(parentCategories => {
+        console.log(parentCategories);
+        const children$ = this.fetchRootCategoriesChildren(parentCategories);
+
+        return children$.pipe(
+          map(children => this.childrenToMap(children)),
+          map(childrenMap => this.categoriesToCategoriesWithChildren(parentCategories, childrenMap))
+        );
+      }));
+  }
+
+  private fetchRootCategoriesChildren(categories: Category[]) {
+    const categoriesToFetch = categories.flatMap(category => category.children);
+    return this.categoryService.getCategories(categoriesToFetch);
+  }
+
+  private childrenToMap(children: Category[]) {
+    const categoryMap = new Map<number, Category>();
+    children.forEach(child => categoryMap.set(child.id, child));
+    return categoryMap;
+  }
+
+  private categoriesToCategoriesWithChildren(parents: Category[], childrenMap: Map<number, Category>) {
+    return parents.map(parentCategory => ({
+      ...parentCategory,
+      children: parentCategory.children.map(childId => childrenMap.get(childId))
+    }));
   }
 
 }

--- a/frontend-implicaction/src/app/forum/model/category.ts
+++ b/frontend-implicaction/src/app/forum/model/category.ts
@@ -3,5 +3,5 @@ export interface Category {
   title: string;
   description?: string;
   parentId?: number;
-  children: Category[];
+  children: number[];
 }

--- a/frontend-implicaction/src/app/forum/services/category.service.ts
+++ b/frontend-implicaction/src/app/forum/services/category.service.ts
@@ -5,7 +5,9 @@ import {Observable} from "rxjs";
 import {Category} from "../model/category";
 import {Pageable} from "../../shared/models/pageable";
 import {Topic} from "../model/topic";
+import {map} from "rxjs/operators";
 
+export type CategoryNode = Category & { children: CategoryNode[]; };
 
 @Injectable({
   providedIn: 'root'
@@ -18,12 +20,50 @@ export class CategoryService {
   ) {
   }
 
-  getCategories(): Observable<Category[]> {
-    return this.http.get<Category[]>(this.apiEndpointService.getAllCategories());
+  getCategories(): Observable<Category[]>;
+  getCategories(ids: number[]): Observable<Category[]>;
+  getCategories(ids?: number[]): Observable<Category[]> {
+    if (ids) {
+      return this.http.get<Category[]>(this.apiEndpointService.getCategories(ids));
+    }
+    return this.http.get<Category[]>(this.apiEndpointService.getCategories());
+  }
+
+  getRootCategories(): Observable<Category[]> {
+    return this.http.get<Category[]>(this.apiEndpointService.getRootCategories());
+  }
+
+  getCategoryTree(): Observable<CategoryNode[]> {
+    return this.getCategories().pipe(map(categories => {
+      // Store each category node by its id
+      const categoryNodeMap = new Map<number, CategoryNode>();
+
+      // convert each category into a category node & add it to the map
+      const categoryNodes = categories.map(category => {
+        const newCategoryNode = {...category, children: []};
+        categoryNodeMap.set(category.id, newCategoryNode);
+        return newCategoryNode;
+      });
+
+      // add each categoryNode to its parent
+      categoryNodes.forEach(categoryNode => {
+        const parentCategory = categoryNodeMap.get(categoryNode.parentId);
+        if (!parentCategory) {
+          return;
+        }
+
+        parentCategory.children.push(categoryNode);
+      });
+
+      // only keep the root categories
+      return categoryNodes.filter(categoryNode => categoryNode.parentId === null);
+    }));
   }
 
   getCategory(id: number): Observable<Category> {
-    return this.http.get<Category>(this.apiEndpointService.getCategory(id));
+    return this.http
+      .get<Category[]>(this.apiEndpointService.getCategory(id))
+      .pipe(map(categories => categories[0]));
   }
 
   getCategoryTopics(id: number, pageable: Pageable<any>): Observable<Pageable<Topic>> {

--- a/frontend-implicaction/tsconfig.json
+++ b/frontend-implicaction/tsconfig.json
@@ -13,7 +13,7 @@
     "target": "es2020",
     "module": "es2020",
     "lib": [
-      "es2018",
+      "es2019",
       "dom"
     ]
   },


### PR DESCRIPTION
Améliore l'implémentation backend de l'API des catégories:
- Permet de récuperer plusieurs catégories par leur ID en même temps, exemple: `/api/forum/categories/1,2,3`;
- L'endpoint `/api/forum/categories` ne renvoies plus un arbre, mais une simple liste de toutes les catégories
- `CategoryDTO.children` n'est plus un `Category[]` mais un `long[]`, qui représente les IDs des enfants.

Coté frontend:
- Ajout d'une méthode `CategoryService#getRootCategories()` qui return la liste des catégories racine.
- L'arbre des catégories est maintenant construit par le front-end `CategoryService#getCategoryTree()`
- `CategoryService#getCategories()` peut avoir des arguments `CategoryService#getCategories(ids: number[])` qui permet de ne récupèrer QUE les catégories ayant ces IDs